### PR TITLE
add special indentation case in tests

### DIFF
--- a/tests/cirru/paren-indent2.cirru
+++ b/tests/cirru/paren-indent2.cirru
@@ -1,0 +1,5 @@
+println
+
+      {} (|two 22) (|three 33)
+      , add |four 44
+    , get |four

--- a/tests/testIndented.nim
+++ b/tests/testIndented.nim
@@ -11,6 +11,11 @@ test "Read parentheses with indent":
   let sourceCode = readFile("tests/cirru/paren-indent.cirru")
   check (toCirru(parseJson(dataCode)) == parseCirru(sourceCode))
 
+test "Read large indent with commas":
+  let dataCode = readFile("tests/data/paren-indent.json")
+  let sourceCode = readFile("tests/cirru/paren-indent2.cirru")
+  check (toCirru(parseJson(dataCode)) == parseCirru(sourceCode))
+
 test "Read indent twice":
   let dataCode = readFile("tests/data/indent-twice.json")
   let sourceCode = readFile("tests/cirru/indent-twice.cirru")


### PR DESCRIPTION
Two snippets:

```cirru
println
      {} (|two 22) (|three 33)
      , add |four 44
    , get |four
```

and

```cirru
println
  (({} (|two 22) (|three 33)) add |four 44) get |four
```

are actually identical after parsing. They look quite different. But comma syntax `,` is special and has the power for unwrap nesting.

Can be confirmed with http://repo.cirru.org/cirru-parser/ .