### PR TITLE
rename types to reduce inconsistency of APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ parseCirru "a b"
 which returns:
 
 ```nim
-(kind: cirruSeq, list: @[(kind: cirruSeq, list: @[(kind: cirruString, text: "a"), (kind: cirruString, text: "b")])])  : CirruNode
+(kind: cirruList, list: @[(kind: cirruList, list: @[(kind: cirruToken, token: "a"), (kind: cirruToken, token: "b")])])  : CirruNode
 ```
 
 `CirruNode` is the type of exprssions and tokens parsed from Cirru code. Browse [types.nim](src/cirru_parser/types.nim) for definitions.
@@ -26,16 +26,16 @@ which returns:
 ```nim
 type
   CirruNodeKind* = enum
-    cirruString,
-    cirruSeq
+    cirruToken,
+    cirruList
 
   CirruNode* = object
     line*: int
     column*: int
     case kind*: CirruNodeKind
-    of cirruString:
-      text*: string
-    of cirruSeq:
+    of cirruToken:
+      token*: string
+    of cirruList:
       list*: DoublyLinkedList[CirruNode]
 ```
 

--- a/cirru_parser.nimble
+++ b/cirru_parser.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.2.4"
+version       = "0.3.0"
 author        = "jiyinyiyong"
 description   = "Parser for Cirru syntax"
 license       = "MIT"
@@ -14,9 +14,9 @@ requires "nim >= 0.20.0"
 
 task t, "Runs the test suite":
   exec "nim c --hints:off -r tests/test_iterator"
-  # exec "nim c --hints:off -r tests/test_parser"
-  # exec "nim c --hints:off -r tests/test_lexer"
-  # exec "nim c --hints:off -r tests/test_types"
+  exec "nim c --hints:off -r tests/test_parser"
+  exec "nim c --hints:off -r tests/test_lexer"
+  exec "nim c --hints:off -r tests/test_types"
 
 task perf, "try large file":
   exec "nim compile --verbosity:0 --profiler:on --stackTrace:on --hints:off -r tests/parse_cost"

--- a/src/cirru_parser/lexer.nim
+++ b/src/cirru_parser/lexer.nim
@@ -16,7 +16,7 @@ proc lexCode*(code: string): DoublyLinkedList[LexNode] =
 
   proc digestBuffer(): void =
     if buffer.len > 0:
-      pieces.append LexNode(kind: lexToken, text: buffer, line: line, column: column)
+      pieces.append LexNode(kind: lexToken, token: buffer, line: line, column: column)
       buffer = ""
 
   proc digestIdentation(): void =
@@ -30,18 +30,18 @@ proc lexCode*(code: string): DoublyLinkedList[LexNode] =
     # echo "indentation:", level
     if level > 0:
       for i in 1..level.int:
-        pieces.append LexNode(kind: lexControl, operator: controlIndent, line: line, column: column)
+        pieces.append LexNode(kind: lexOperator, operator: controlIndent, line: line, column: column)
     elif level < 0:
       for i in 1..(-level.int):
-        pieces.append LexNode(kind: lexControl, operator: controlOutdent, line: line, column: column)
+        pieces.append LexNode(kind: lexOperator, operator: controlOutdent, line: line, column: column)
       # special logic to generate extra newline ops
-      pieces.append LexNode(kind: lexControl, operator: controlOutdent, line: line, column: column)
-      pieces.append LexNode(kind: lexControl, operator: controlIndent, line: line, column: column)
+      pieces.append LexNode(kind: lexOperator, operator: controlOutdent, line: line, column: column)
+      pieces.append LexNode(kind: lexOperator, operator: controlIndent, line: line, column: column)
 
     else:
       if pieces.head.isNil.not:
-        pieces.append LexNode(kind: lexControl, operator: controlOutdent, line: line, column: column)
-        pieces.append LexNode(kind: lexControl, operator: controlIndent, line: line, column: column)
+        pieces.append LexNode(kind: lexOperator, operator: controlOutdent, line: line, column: column)
+        pieces.append LexNode(kind: lexOperator, operator: controlIndent, line: line, column: column)
 
     previousIndentation = indentation
     # echo "previousIndentation: ", previousIndentation
@@ -73,7 +73,7 @@ proc lexCode*(code: string): DoublyLinkedList[LexNode] =
         lexingState = lexStateString
       of '(':
         digestIdentation()
-        pieces.append LexNode(kind: lexControl, operator: controlParenOpen, line: line, column: column)
+        pieces.append LexNode(kind: lexOperator, operator: controlParenOpen, line: line, column: column)
         lexingState = lexStateSpace
       of ')':
         raiseParseException("Unexpected ) in line head", line, column)
@@ -97,7 +97,7 @@ proc lexCode*(code: string): DoublyLinkedList[LexNode] =
       of '"':
         lexingState = lexStateSpace
         # special case, add even if token is empty
-        pieces.append LexNode(kind: lexToken, text: buffer, line: line, column: column)
+        pieces.append LexNode(kind: lexToken, token: buffer, line: line, column: column)
         buffer = ""
       else:
         buffer.add c
@@ -113,10 +113,10 @@ proc lexCode*(code: string): DoublyLinkedList[LexNode] =
       of '(':
         if buffer.strip().len > 0:
           digestBuffer()
-        pieces.append LexNode(kind: lexControl, operator: controlParenOpen, line: line, column: column)
+        pieces.append LexNode(kind: lexOperator, operator: controlParenOpen, line: line, column: column)
         lexingState = lexStateSpace
       of ')':
-        pieces.append LexNode(kind: lexControl, operator: controlParenClose, line: line, column: column)
+        pieces.append LexNode(kind: lexOperator, operator: controlParenClose, line: line, column: column)
         digestBuffer()
         lexingState = lexStateSpace
       else:
@@ -130,11 +130,11 @@ proc lexCode*(code: string): DoublyLinkedList[LexNode] =
       of '(':
         if buffer.len > 0:
           digestBuffer()
-        pieces.append LexNode(kind: lexControl, operator: controlParenOpen, line: line, column: column)
+        pieces.append LexNode(kind: lexOperator, operator: controlParenOpen, line: line, column: column)
         lexingState = lexStateSpace
       of ')':
         digestBuffer()
-        pieces.append LexNode(kind: lexControl, operator: controlParenClose, line: line, column: column)
+        pieces.append LexNode(kind: lexOperator, operator: controlParenClose, line: line, column: column)
         lexingState = lexStateSpace
       of '\n':
         digestBuffer()
@@ -144,7 +144,7 @@ proc lexCode*(code: string): DoublyLinkedList[LexNode] =
 
   case lexingState
   of lexStateToken:
-    pieces.append LexNode(kind: lexToken, text: buffer, line: line, column: column)
+    pieces.append LexNode(kind: lexToken, token: buffer, line: line, column: column)
   of lexStateEscape:
     raiseParseException("EOF at escape", line, column)
   of lexStateString:

--- a/tests/test_lexer.nim
+++ b/tests/test_lexer.nim
@@ -1,5 +1,5 @@
 
-import lists
+# import lists
 import unittest
 
 import cirru_parser/types
@@ -9,14 +9,14 @@ import cirru_parser/helpers
 test "Lex nodes equality":
   check (@[genLexToken("a")] == @[genLexToken("a")])
   check (@[genLexToken("a")] != @[genLexToken("b")])
-  check (@[genLexControl(controlIndent)] == @[genLexControl(controlIndent)])
-  check (@[genLexToken("a")] != @[genLexControl(controlIndent)])
+  check (@[genLexOperator(controlIndent)] == @[genLexOperator(controlIndent)])
+  check (@[genLexToken("a")] != @[genLexOperator(controlIndent)])
 
 test "Lex code":
   check (lexCode("a b").toSeq == @[genLexToken("a"), genLexToken("b")])
   check (lexCode("a \"b\"").toSeq == @[genLexToken("a"), genLexToken("b")])
   check (lexCode("a \"b c\"").toSeq == @[genLexToken("a"), genLexToken("b c")])
-  check (lexCode("a\n  b").toSeq == @[genLexToken("a"), genLexControl(controlIndent), genLexToken("b")])
-  check (lexCode("a (b c)").toSeq == @[genLexToken("a"), genLexControl(controlParenOpen),
-                                            genLexToken("b"), genLexToken("c"), genLexControl(controlParenClose)])
-  check (lexCode("a\n  \"b\"").toSeq == @[genLexToken("a"), genLexControl(controlIndent), genLexToken("b")])
+  check (lexCode("a\n  b").toSeq == @[genLexToken("a"), genLexOperator(controlIndent), genLexToken("b")])
+  check (lexCode("a (b c)").toSeq == @[genLexToken("a"), genLexOperator(controlParenOpen),
+                                            genLexToken("b"), genLexToken("c"), genLexOperator(controlParenClose)])
+  check (lexCode("a\n  \"b\"").toSeq == @[genLexToken("a"), genLexOperator(controlIndent), genLexToken("b")])

--- a/tests/test_parser.nim
+++ b/tests/test_parser.nim
@@ -10,50 +10,50 @@ test "Parse parens":
   var a1 = @[
     genLexToken("a"),
     genLexToken("b"),
-    genLexControl(controlParenClose),
+    genLexOperator(controlParenClose),
   ].toLinkedList
   let b1 = %* ["a", "b"]
-  check (CirruNode(kind: cirruSeq, list: digestParsingParens(a1)) == toCirru(b1))
+  check (CirruNode(kind: cirruList, list: digestParsingParens(a1)) == toCirru(b1))
   var a2 = @[
     genLexToken("a"),
-    genLexControl(controlParenOpen),
+    genLexOperator(controlParenOpen),
     genLexToken("b"),
-    genLexControl(controlParenClose),
-    genLexControl(controlParenClose),
+    genLexOperator(controlParenClose),
+    genLexOperator(controlParenClose),
   ].toLinkedList
   let b2 = %* ["a", ["b"]]
-  check (CirruNode(kind: cirruSeq, list: digestParsingParens(a2)) == toCirru(b2))
+  check (CirruNode(kind: cirruList, list: digestParsingParens(a2)) == toCirru(b2))
 
 test "Parse indentation":
   var a1 = @[
     genLexToken("a"),
-    genLexControl(controlOutdent),
+    genLexOperator(controlOutdent),
   ].toLinkedList
   let b1 = %* ["a"]
-  check (CirruNode(kind: cirruSeq, list: digestParsingIndentation(a1)) == toCirru(b1))
+  check (CirruNode(kind: cirruList, list: digestParsingIndentation(a1)) == toCirru(b1))
 
   var a2 = @[
     genLexToken("a"),
-    genLexControl(controlIndent),
+    genLexOperator(controlIndent),
     genLexToken("b"),
-    genLexControl(controlOutdent),
-    genLexControl(controlOutdent),
+    genLexOperator(controlOutdent),
+    genLexOperator(controlOutdent),
   ].toLinkedList
   let b2 = %* ["a", ["b"]]
-  check (CirruNode(kind: cirruSeq, list: digestParsingIndentation(a2)) == toCirru(b2))
+  check (CirruNode(kind: cirruList, list: digestParsingIndentation(a2)) == toCirru(b2))
 
   var a3 = @[
     genLexToken("a"),
-    genLexControl(controlIndent),
+    genLexOperator(controlIndent),
     genLexToken("b"),
-    genLexControl(controlOutdent),
-    genLexControl(controlIndent),
+    genLexOperator(controlOutdent),
+    genLexOperator(controlIndent),
     genLexToken("c"),
-    genLexControl(controlOutdent),
-    genLexControl(controlOutdent),
+    genLexOperator(controlOutdent),
+    genLexOperator(controlOutdent),
   ].toLinkedList
   let b3 = %* ["a", ["b"], ["c"]]
-  check (CirruNode(kind: cirruSeq, list: digestParsingIndentation(a3)) == toCirru(b3))
+  check (CirruNode(kind: cirruList, list: digestParsingIndentation(a3)) == toCirru(b3))
 
 
 test "Parse simple program":
@@ -67,7 +67,7 @@ test "Parse simple program":
   check (parseCirru("a\n  b\nc") == toCirru(a3))
 
 test "Parse empty program":
-  check (parseCirru("") == CirruNode(kind: cirruSeq, list: initDoublyLinkedList[CirruNode]()))
+  check (parseCirru("") == CirruNode(kind: cirruList, list: initDoublyLinkedList[CirruNode]()))
 
 test "Converts to JSON":
   check (toJson(parseCirru("a $ b $ c")) == %* [["a", ["b", ["c"]]]])

--- a/tests/test_types.nim
+++ b/tests/test_types.nim
@@ -8,17 +8,17 @@ import cirru_parser/types
 import cirru_parser/helpers
 
 test "nodes comparing":
-  let a1 = CirruNode(kind: cirruString, text: "a")
-  let a2 = CirruNode(kind: cirruString, text: "a")
+  let a1 = CirruNode(kind: cirruToken, token: "a")
+  let a2 = CirruNode(kind: cirruToken, token: "a")
 
   check (a1 == a2)
 
-  let a3 = CirruNode(kind: cirruString, text: "b")
+  let a3 = CirruNode(kind: cirruToken, token: "b")
   check (a1 != a3)
 
   let b0 = initDoublyLinkedList[CirruNode]()
-  let b1 = CirruNode(kind: cirruSeq, list: b0)
-  let b2 = CirruNode(kind: cirruSeq, list: b0)
+  let b1 = CirruNode(kind: cirruList, list: b0)
+  let b2 = CirruNode(kind: cirruList, list: b0)
   check (b1 == b2)
 
   check (a1 != b1)
@@ -26,17 +26,17 @@ test "nodes comparing":
 test "Cirru from JSON":
 
   let jsonNodeOfC = JsonNode(kind: JString, str: "c")
-  let nodeOfC = CirruNode(kind: cirruString, text: "c")
+  let nodeOfC = CirruNode(kind: cirruToken, token: "c")
   check (toCirru(jsonNodeOfC) == nodeOfC)
 
   let jsonEmpty = %* []
-  let nodeOfEmpty = CirruNode(kind: cirruSeq, list: initDoublyLinkedList[CirruNode]())
+  let nodeOfEmpty = CirruNode(kind: cirruList, list: initDoublyLinkedList[CirruNode]())
   check (toCirru(jsonEmpty) == nodeOfEmpty)
 
   let jsonArray = %* ["a"]
-  let nodeOfArray = CirruNode(kind: cirruSeq, list: @[CirruNode(kind: cirruString, text: "a")].toLinkedList)
+  let nodeOfArray = CirruNode(kind: cirruList, list: @[CirruNode(kind: cirruToken, token: "a")].toLinkedList)
   check (toCirru(jsonArray) == nodeOfArray)
 
   let jsonNested = %* [[]]
-  let nodeOfNested = CirruNode(kind: cirruSeq, list: @[CirruNode(kind: cirruSeq, list: initDoublyLinkedList[CirruNode]())].toLinkedList)
+  let nodeOfNested = CirruNode(kind: cirruList, list: @[CirruNode(kind: cirruList, list: initDoublyLinkedList[CirruNode]())].toLinkedList)
   check (toCirru(jsonNested) == nodeOfNested)


### PR DESCRIPTION
new Names for parser:

- `cirruToken`, `token`
- `cirruList`, `list`

Lexer:

- `lexToken`, `token`
- `lexOperator`, `operator`